### PR TITLE
Adding backticks to correct formatting

### DIFF
--- a/src/contrib.md
+++ b/src/contrib.md
@@ -62,6 +62,6 @@ Larger images should be posted to some image-hosting, like [PostImage](http://po
 
 Template for the pages (the one which creates small violet header and footer, determines the layout of the text, includes css and js files) is now also stored in this repo, in [src/\_templates](https://github.com/e-maxx-eng/e-maxx-eng/tree/master/src/_templates) folder. So in case you find some bugs in it, or with the passing of time some new features may be needed in it - create PR to improve it. Note that for testing purposes the alternative template could be created and used for specific page with the inclusion of special comment as shown below:
 
-    <!--?template myfunnytemplate-->
+ `<!--?template myfunnytemplate-->`
 
 The templates are cached for about 3600 seconds, rather than 300 seconds for ordinary pages, so be patient :)


### PR DESCRIPTION
Without it, I get the following error:
![error](https://i.imgur.com/txwYaOy.png)